### PR TITLE
fixed error when pressing back button at the toolbar of the MessageActivity

### DIFF
--- a/app/src/main/java/com/wakilifinder/wakilifinder/MessageActivity.java
+++ b/app/src/main/java/com/wakilifinder/wakilifinder/MessageActivity.java
@@ -65,7 +65,16 @@ public class MessageActivity extends AppCompatActivity {
         toolbar.setNavigationOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                startActivity(new Intent(MessageActivity.this, HomeLawyer.class).setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP));
+
+                String userloggedin = intent.getStringExtra("user");
+
+                if (userloggedin.equals("client")){
+                    startActivity(new Intent(MessageActivity.this, HomeClient.class).setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP));
+                }
+                else if (userloggedin.equals("lawyer")){
+                    startActivity(new Intent(MessageActivity.this, HomeLawyer.class).setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP));
+                }
+
             }
         });
 


### PR DESCRIPTION
MessageActivity had an issue where when back button is pressed it opened the wrong activity. This is now fixed.